### PR TITLE
Use the values of the S2S_SECRET and S2S_MICROSERVICE env vars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ plugins {
 apply plugin: 'java'
 
 def versions = [
+    lombok          : '1.18.6',
     serenity        : '2.0.11',
     springBoot      : '2.0.4.RELEASE',
     springHystrix   : '2.0.2.RELEASE',
@@ -78,6 +79,10 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.21.0'
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
 
+    compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    testCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 }
 
 gradle.startParameter.continueOnFailure = true

--- a/src/main/java/uk/gov/hmcts/reform/servicetokenprovider/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/servicetokenprovider/Application.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.servicetokenprovider;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -20,11 +21,15 @@ import uk.gov.hmcts.reform.authorisation.generators.ServiceAuthTokenGenerator;
         "uk.gov.hmcts.reform.authorisation",
         "uk.gov.hmcts.reform.servicetokenprovider",
     })
+@Slf4j
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 
     @Value("${idam.s2s-auth.totp_secret}")
     private String secret;
+
+    @Value("${idam.s2s-auth.microservice}")
+    private String microservice;
 
     @Autowired
     private ServiceAuthorisationApi serviceAuthorisationApi;
@@ -35,6 +40,7 @@ public class Application {
 
     @Bean
     public AuthTokenGenerator authTokenGenerator() {
-        return new ServiceAuthTokenGenerator(secret, "iac", serviceAuthorisationApi);
+        log.info(String.format("Creating token generator with secret {} and microservice {}", secret, microservice));
+        return new ServiceAuthTokenGenerator(secret, microservice, serviceAuthorisationApi);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -3,6 +3,6 @@ server:
 
 ### dependency configuration
 auth.provider.service.client.baseUrl: ${S2S_URL:http://127.0.0.1:4502}
-idam.s2s-auth.totp_secret: ${IA_S2S_SECRET:AAAAAAAAAAAAAAAC}
-idam.s2s-auth.microservice: ${IA_S2S_MICROSERVICE:iac}
+idam.s2s-auth.totp_secret: ${S2S_SECRET:AAAAAAAAAAAAAAAC}
+idam.s2s-auth.microservice: ${S2S_MICROSERVICE:iac}
 idam.s2s-auth.url: ${S2S_URL:http://127.0.0.1:4502}


### PR DESCRIPTION
Use the values of the S2S_SECRET and S2S_MICROSERVICE env vars to create the auth token generator

This means it can be used by any service, not just ones set up the same as iac

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
